### PR TITLE
Upgrade to lazy-microstates api.

### DIFF
--- a/app/screens/dosage-show.js
+++ b/app/screens/dosage-show.js
@@ -34,9 +34,9 @@ class DosageShow extends Component {
               ? `Expired ${dosage.timeLeft}`
               : `Expires ${dosage.timeLeft}`}
           </Text>
-          <Text style={styles.showText}>{dosage.state.dosage}</Text>
+          <Text style={styles.showText}>{dosage.dosage.state}</Text>
           <Text style={styles.showText}>
-            Duration: {dosage.state.dosageDuration} hours
+            Duration: {dosage.dosageDuration.state} hours
           </Text>
           <Text style={styles.showText}>
             {`Taken at ${dosage.formattedTakenTime} and expires at ${

--- a/app/screens/home.js
+++ b/app/screens/home.js
@@ -31,7 +31,7 @@ class HomeScreen extends Component {
       return null;
     } else {
       return dosage.map((dosage, index) => {
-        let subtitle = `${dosage.state.dosage} ${"\u2022"} ${
+        let subtitle = `${dosage.dosage.state} ${"\u2022"} ${
           dosage.formattedTakenTime
         } / ${dosage.formattedExpireTime} ${"\u2022"} ${
           dosage.formattedTakenFullDate
@@ -39,7 +39,7 @@ class HomeScreen extends Component {
         return (
           <ListItem
             key={index}
-            title={dosage.state.name}
+            title={dosage.name.state}
             chevronColor="#FF715B"
             containerStyle={styles.listContainer}
             titleStyle={styles.listTitle}
@@ -57,7 +57,7 @@ class HomeScreen extends Component {
   render() {
     let { model } = this.props.screenProps;
 
-    if (!model.state.dosages.length) {
+    if (!model.dosages.state.length) {
       return (
         <View style={styles.emptyStateContainer}>
           <Text style={styles.emptyStateTitle}>No Dosages</Text>

--- a/app/screens/new-dosage/form-model.js
+++ b/app/screens/new-dosage/form-model.js
@@ -10,13 +10,13 @@ class FormModel extends Medication {
   }
 
   get isValid() {
-    let { name, timeTaken, dosage, dosageDuration } = this.state;
+    let { name, timeTaken, dosage, dosageDuration } = this;
 
     if (
-      name.length &&
-      !!timeTaken &&
-      dosageDuration &&
-      dosage.length &&
+      name.state.length &&
+      !!timeTaken.state &&
+      dosageDuration.state &&
+      dosage.state.length &&
       this.durationIsAnHour
     ) {
       return true;

--- a/app/screens/new-dosage/index.js
+++ b/app/screens/new-dosage/index.js
@@ -37,16 +37,16 @@ class NewDosageScreen extends Component {
     let AppModel = this.props.screenProps.model;
     let currentDate = new Date();
     let newDosage = {
-      name: formModel.state.name,
-      dosage: formModel.state.dosage,
-      timeTaken: formModel.state.timeTaken,
-      dosageDuration: formModel.state.dosageDuration
+      name: formModel.name.state,
+      dosage: formModel.dosage.state,
+      timeTaken: formModel.timeTaken.state,
+      dosageDuration: formModel.dosageDuration.state
     };
 
     AppModel.dosages.push(newDosage);
 
     PushNotification.localNotificationSchedule({
-      message: `Your dosage ${formModel.state.name} will expire at ${
+      message: `Your dosage ${formModel.name.state} will expire at ${
         formModel.formattedExpireTime
       }`,
       date: formModel.notificationDate,
@@ -104,7 +104,7 @@ class NewDosageScreen extends Component {
                   buttonStyle={styles.takenTimeBtn}
                   rightIcon={{
                     color: "black",
-                    name: formModel.state.showPicker
+                    name: formModel.showPicker.state
                       ? "arrow-drop-up"
                       : "arrow-drop-down",
                     size: 25
@@ -112,9 +112,9 @@ class NewDosageScreen extends Component {
                   onPress={() => this.handlePickerTap(formModel)}
                 />
 
-                {formModel.state.showPicker && (
+                {formModel.showPicker.state && (
                   <DatePickerIOS
-                    date={formModel.state.timeTaken}
+                    date={formModel.timeTaken.state}
                     maximumDate={new Date()}
                     mode="time"
                     onDateChange={date => formModel.timeTaken.set(date)}


### PR DESCRIPTION
The next version of microstates will probably not allow access of the `state` property from non-leaf nodes, so usages like `dosage.state.dosage` will be broken and need to be re-written as `dosage.dosage.state`

See https://github.com/microstates/microstates.js/pull/222 for details.

The good news is that this works with the current version of microstates, so upgrading is not required. But it is forward compatible with the new syntax.